### PR TITLE
Add get_current_block to Cpu

### DIFF
--- a/icicle-cpu/src/cpu.rs
+++ b/icicle-cpu/src/cpu.rs
@@ -529,6 +529,20 @@ impl Cpu {
         self.mem.read_bytes(addr, &mut buf[..ptr_size as usize], perm::READ)?;
         Ok(self.arch.bytes_to_pointer(buf))
     }
+
+    pub fn get_current_block(&self, code: &BlockTable) -> Option<(u64, u64)> {
+        match self.block_id != u64::MAX {
+            true => Some((self.block_id, self.block_offset)),
+            false => {
+                let key = BlockKey {
+                    vaddr: self.read_pc(),
+                    isa_mode: self.isa_mode() as u64
+                };
+                let id = code.map.get(&key).map(|group| group.blocks.0)?;
+                Some((id as u64, 0))
+            }
+        }
+    } 
 }
 
 impl ValueSource for Cpu {

--- a/icicle-vm/src/lib.rs
+++ b/icicle-vm/src/lib.rs
@@ -523,14 +523,7 @@ impl Vm {
     /// Return the currently active block and offset. If no block is active, retrieve the next block
     /// based on the current program counter.
     pub fn get_current_block(&self) -> Option<(u64, u64)> {
-        match self.cpu.block_id != u64::MAX {
-            true => Some((self.cpu.block_id, self.cpu.block_offset)),
-            false => {
-                let key = self.get_block_key(self.cpu.read_pc());
-                let id = self.code.map.get(&key).map(|group| group.blocks.0)?;
-                Some((id as u64, 0))
-            }
-        }
+        self.cpu.get_current_block(&self.code)
     }
 
     pub fn reset(&mut self) {


### PR DESCRIPTION
Add `get_current_block` to `Cpu` to be available in injectors, inject method of `CodeInjector` trait does not provide `Vm`.